### PR TITLE
reduce excessive server connection attempts

### DIFF
--- a/autogtp/Management.cpp
+++ b/autogtp/Management.cpp
@@ -75,9 +75,9 @@ void Management::runTuningProcess(const QString &tuneCmdLine) {
 }
 
 Order Management::getWork(const QFileInfo &file) {
-    QTextStream(stdout) << "Got previously stored file" <<endl;
     Order o;
     if(!file.fileName().isEmpty()) {
+        QTextStream(stdout) << "Got previously stored file" <<endl;
         o.load(file.fileName());
         QFile::remove(file.fileName());
         m_lockFile->unlock();
@@ -753,7 +753,7 @@ void Management::uploadData(const QMap<QString,QString> &r, const QMap<QString,Q
 
     connectionFail = false;
     bool sent = false;
-    for (auto retries = 0; retries < MAX_RETRIES; retries++) {
+    for (auto retries = 0; retries <= MAX_RETRIES; retries++) {
         try {
             sent = sendCurl(prog_cmdline);
             break; // actually no retries?

--- a/autogtp/Management.cpp
+++ b/autogtp/Management.cpp
@@ -588,6 +588,7 @@ void Management::sendAllGames() {
     filters << "curl_save*.bin";
     dir.setNameFilters(filters);
     dir.setFilter(QDir::Files | QDir::NoSymLinks);
+    dir.setSorting(QDir::Time);
     QFileInfoList list = dir.entryInfoList();
     for (int i = 0; i < list.size() && !connectionFail; ++i) {
         QFileInfo fileInfo = list.at(i);
@@ -783,5 +784,6 @@ void Management::checkStoredGames() {
     filters << "storefile*.bin";
     dir.setNameFilters(filters);
     dir.setFilter(QDir::Files | QDir::NoSymLinks);
+    dir.setSorting(QDir::Time);
     m_storedFiles = dir.entryInfoList();
 }

--- a/autogtp/Management.cpp
+++ b/autogtp/Management.cpp
@@ -36,6 +36,7 @@ constexpr int RETRY_DELAY_MAX_SEC = 60 * 60;  // 1 hour
 constexpr int MAX_RETRIES = 3;           // Stop retrying after 3 times
 const QString Leelaz_min_version = "0.11";
 bool connectionFail = false;
+bool selfPlayOnly = false;
 
 Management::Management(const int gpus,
                        const int games,
@@ -304,7 +305,7 @@ Order Management::getWorkInternal(bool tuning) {
 #endif
     prog_cmdline.append(" -s -J");
     prog_cmdline.append(" http://zero.sjeng.org/get-task/");
-    if (tuning) {
+    if (tuning || selfPlayOnly) {
         prog_cmdline.append("0");
     } else {
         prog_cmdline.append(QString::number(AUTOGTP_VERSION));

--- a/autogtp/Management.cpp
+++ b/autogtp/Management.cpp
@@ -410,7 +410,7 @@ Order Management::getWorkInternal(bool tuning) {
 }
 
 Order Management::getWork(bool tuning) {
-    for (auto retries = 0; retries < MAX_RETRIES; retries++) {
+    for (auto retries = 0; retries <= MAX_RETRIES; retries++) {
         try {
             return getWorkInternal(tuning);
         } catch (NetworkException ex) {
@@ -418,6 +418,9 @@ Order Management::getWork(bool tuning) {
                 << "Network connection to server failed." << endl;
             QTextStream(stdout)
                 << ex.what() << endl;
+            if (retries == MAX_RETRIES) {
+                break;
+            }
             auto retry_delay =
                 std::min<int>(
                     RETRY_DELAY_MIN_SEC * std::pow(1.5, retries),
@@ -700,15 +703,18 @@ void Management::uploadResult(const QMap<QString,QString> &r, const QMap<QString
 
     connectionFail = false;
     bool sent = false;
-    for (auto retries = 0; retries < MAX_RETRIES; retries++) {
+    for (auto retries = 0; retries <= MAX_RETRIES; retries++) {
         try {
             sent = sendCurl(prog_cmdline);
-            break;
+            break; // actually no retries?
         } catch (NetworkException ex) {
             QTextStream(stdout)
                 << "Network connection to server failed." << endl;
             QTextStream(stdout)
                 << ex.what() << endl;
+            if (retries == MAX_RETRIES) {
+                break;
+            }
             auto retry_delay =
                 std::min<int>(
                     RETRY_DELAY_MIN_SEC * std::pow(1.5, retries),
@@ -756,12 +762,15 @@ void Management::uploadData(const QMap<QString,QString> &r, const QMap<QString,Q
     for (auto retries = 0; retries < MAX_RETRIES; retries++) {
         try {
             sent = sendCurl(prog_cmdline);
-            break;
+            break; // actually no retries?
         } catch (NetworkException ex) {
             QTextStream(stdout)
                 << "Network connection to server failed." << endl;
             QTextStream(stdout)
                 << ex.what() << endl;
+            if (retries == MAX_RETRIES) {
+                break;
+            }
             auto retry_delay =
                 std::min<int>(
                     RETRY_DELAY_MIN_SEC * std::pow(1.5, retries),

--- a/autogtp/main.cpp
+++ b/autogtp/main.cpp
@@ -39,6 +39,7 @@
 #include "Console.h"
 
 int main(int argc, char *argv[]) {
+    bool consoleOn = true;
     QCoreApplication app(argc, argv);
     app.setApplicationName("autogtp");
     app.setApplicationVersion(QString("v%1").arg(AUTOGTP_VERSION));
@@ -135,16 +136,16 @@ int main(int argc, char *argv[]) {
     QObject::connect(&app, &QCoreApplication::aboutToQuit, boss, &Management::storeGames);
     QTimer *timer = new QTimer();
     boss->giveAssignments();
+    if (parser.isSet(singleOption) || parser.isSet(maxOption)) {
+        QObject::connect(boss, &Management::sendQuit, &app, &QCoreApplication::quit);
+    }
     if(parser.isSet(timeoutOption)) {
         QObject::connect(timer, &QTimer::timeout, &app, &QCoreApplication::quit);
         timer->start(parser.value(timeoutOption).toInt() * 60000);
-    } else {
-        if (parser.isSet(singleOption) || parser.isSet(maxOption)) {
-            QObject::connect(boss, &Management::sendQuit, &app, &QCoreApplication::quit);
-        } else {
-            cons = new Console();
-            QObject::connect(cons, &Console::sendQuit, &app, &QCoreApplication::quit);
-        }
+    }
+    if(consoleOn)
+        cons = new Console();
+        QObject::connect(cons, &Console::sendQuit, &app, &QCoreApplication::quit);
     }
     return app.exec();
 }

--- a/autogtp/main.cpp
+++ b/autogtp/main.cpp
@@ -136,14 +136,14 @@ int main(int argc, char *argv[]) {
     QObject::connect(&app, &QCoreApplication::aboutToQuit, boss, &Management::storeGames);
     QTimer *timer = new QTimer();
     boss->giveAssignments();
-    if (parser.isSet(singleOption) || parser.isSet(maxOption)) {
-        QObject::connect(boss, &Management::sendQuit, &app, &QCoreApplication::quit);
-    }
     if(parser.isSet(timeoutOption)) {
         QObject::connect(timer, &QTimer::timeout, &app, &QCoreApplication::quit);
         timer->start(parser.value(timeoutOption).toInt() * 60000);
     }
-    if(consoleOn)
+    if (parser.isSet(singleOption) || parser.isSet(maxOption)) {
+        QObject::connect(boss, &Management::sendQuit, &app, &QCoreApplication::quit);
+    }
+    if(consoleOn) {
         cons = new Console();
         QObject::connect(cons, &Console::sendQuit, &app, &QCoreApplication::quit);
     }


### PR DESCRIPTION
Introduce global variable `connectionFail` which will be set to false if an attempt to download/upload (through curl) small files (get-task, upload data/result) fails. The variable is reset to false after each game.
`sendAllGames` (but not `getWork`) will not run when `connectionFail = true`.